### PR TITLE
fix: LZ-8, fix iam to deal with situations where original bucket exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Core Components:
 
 This serverless architecture ensures efficient resource usage while maintaining high performance and scalability. The system processes each image request through a well-defined flow, which is illustrated in the following diagram.
 
-<img src="architecture.png" width="900">
+![The proposed solution architecture](architecture.png)
 
 ## Overview
 

--- a/iam.tf
+++ b/iam.tf
@@ -20,9 +20,9 @@ data "aws_iam_policy_document" "lambda_policy_document" {
 
     resources = [
       module.transformed_s3_bucket.s3_bucket_arn,
-      module.original_s3_bucket.s3_bucket_arn,
       "${module.transformed_s3_bucket.s3_bucket_arn}/*",
-      "${module.original_s3_bucket.s3_bucket_arn}/*"
+      "arn:aws:s3:::${var.original_image_bucket_name}",
+      "arn:aws:s3:::${var.original_image_bucket_name}/*"
     ]
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -15,13 +15,13 @@ module "image_optimization_lambda" {
   authorization_type         = "AWS_IAM"
 
   layers = [
-    "arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-p39-pillow:1"
+    var.lambda_layer_arn
   ]
 
   policy_json = data.aws_iam_policy_document.lambda_policy_document.json
 
   environment_variables = {
-    originalImageBucketName    = module.original_s3_bucket.s3_bucket_id
+    originalImageBucketName    = var.original_image_bucket_name
     transformedImageBucketName = module.transformed_s3_bucket.s3_bucket_id
     maxImageSize               = var.max_image_size
     transformedImageCacheTTL   = var.image_cache_ttl

--- a/s3.tf
+++ b/s3.tf
@@ -9,7 +9,7 @@ module "original_s3_bucket" {
 
   create_bucket = var.create_origin_bucket
 
-  bucket = lower("${var.original_image_bucket_name}-${random_id.random_id.id}")
+  bucket = var.original_image_bucket_name
   acl    = "private"
 
   control_object_ownership = true

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "aws_region" {
 variable "create_origin_bucket" {
   description = "Create an S3 bucket for original images"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "original_image_bucket_name" {
@@ -52,4 +52,9 @@ variable "image_cache_ttl" {
   description = "TTL for transformed images in seconds"
   type        = string
   default     = "max-age=31622400"
+}
+
+variable "lambda_layer_arn" {
+  description = "ARN of the Lambda layer" #used for adding the Pillow library layer
+  type        = string
 }


### PR DESCRIPTION
Adjusted IAM policy to create S3 ARN for origin bucket access from variable in case origin bucket exists.

Moved Lambda layer arn to variable as those are region specific. ( Will need to build Pillow layer to not depend on a external layer )

Some minor fixes to Readme.

